### PR TITLE
[JET-17506] give some time for the bridge to startup

### DIFF
--- a/lib/util_mosq.c
+++ b/lib/util_mosq.c
@@ -105,6 +105,7 @@ int mosquitto__check_keepalive(struct mosquitto *mosq)
 		}else{
 #ifdef WITH_BROKER
 #  ifdef WITH_BRIDGE
+      log__printf(NULL, MOSQ_LOG_NOTICE, "rkdb: mosquitto__check_keepalive closing socket %d for %s", mosq->sock, mosq->id);
 			if(mosq->bridge){
 				context__send_will(mosq);
 			}


### PR DESCRIPTION
I noticed that with the new aggressive restart_timeout of 5 seconds in 02_bridge.conf, mosquitto can struggle a bit getting the bridge going again (take 2 or 3 minutes) after an EMQX node is replaced.  I think that this is because thousands of our liveunits are trying to reconnect at once, and 5 seconds is not enough time for all of them to reconnect (nor do I think it should ever assume 5 seconds is enough when it is actively trying to restart the bridge).

This change is to give it a minute (literally) to establish a connection before allowing bridge_check() or mosquitto__check_keepalive() to give up on it.

## Testing
* regression testing on mobile_6
* coordinating with Tyler to restart an EMQX node and watch the behavior

## logs from 10.23.36.172
```
Feb 26 11:03:03 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740592983: Client local.ffcb0b7d-0a1e-11ee-bdd8-06a1f89ff547 closed its connection.
Feb 26 11:03:03 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740592983: rkdb: context_disconnect() called for bridge bridge
Feb 26 11:03:03 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740592983: rkdb: setting restart time to 5 seconds from now
Feb 26 11:03:09 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740592989: rkdb: adns restart: bridge
Feb 26 11:03:09 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740592989: rkdb: Connecting bridge (step 1) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:03:09 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740592989: rkdb: Connecting bridge (step 2) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:03:09 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740592989: rkdb: Connecting bridge (step 3) bridge (emqx.prd.lvt.services)
Feb 26 11:03:14 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740592994: rkdb: setting restart time to 5 seconds from now
Feb 26 11:03:17 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740592997: rkdb: connection is down - checking if I should try to restart: bridge
Feb 26 11:03:20 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740593000: rkdb: adns restart: bridge
Feb 26 11:03:20 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740593000: rkdb: Connecting bridge (step 1) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:03:20 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740593000: rkdb: Connecting bridge (step 2) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:03:20 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740593000: rkdb: Connecting bridge (step 3) bridge (emqx.prd.lvt.services)
Feb 26 11:03:25 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740593005: rkdb: setting restart time to 5 seconds from now
Feb 26 11:03:31 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740593011: rkdb: adns restart: bridge
Feb 26 11:03:31 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740593011: rkdb: Connecting bridge (step 1) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:03:31 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740593011: rkdb: Connecting bridge (step 2) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:03:31 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740593011: rkdb: Connecting bridge (step 3) bridge (emqx.prd.lvt.services)
Feb 26 11:03:33 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740593013: mosquitto version 2.0.20 terminating
Feb 26 11:03:33 LVT-RPI-EDGE-V402 systemd[1]: Stopping Mosquitto MQTT Broker...
Feb 26 11:03:33 LVT-RPI-EDGE-V402 mosquitto[3630528]: 1740593013: rkdb: context_disconnect() called for bridge bridge
Feb 26 11:03:34 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593014: rkdb: Connecting bridge (step 1) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:03:34 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593014: rkdb: Connecting bridge (step 2) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:03:34 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593014: rkdb: Connecting bridge (step 3) bridge (emqx.prd.lvt.services)
Feb 26 11:03:38 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593018: rkdb: setting restart time to 5 seconds from now
Feb 26 11:03:41 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593021: rkdb: connection is down - checking if I should try to restart: bridge
Feb 26 11:03:44 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593024: rkdb: adns restart: bridge
Feb 26 11:03:44 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593024: rkdb: Connecting bridge (step 1) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:03:44 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593024: rkdb: Connecting bridge (step 2) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:03:44 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593024: rkdb: Connecting bridge (step 3) bridge (emqx.prd.lvt.services)
Feb 26 11:03:49 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593029: rkdb: setting restart time to 5 seconds from now
Feb 26 11:03:55 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593035: rkdb: adns restart: bridge
Feb 26 11:03:55 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593035: rkdb: Connecting bridge (step 1) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:03:55 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593035: rkdb: Connecting bridge (step 2) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:03:56 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593036: rkdb: Connecting bridge (step 3) bridge (emqx.prd.lvt.services)
Feb 26 11:04:07 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593047: rkdb: setting restart time to 5 seconds from now
Feb 26 11:04:10 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593050: rkdb: connection is down - checking if I should try to restart: bridge
Feb 26 11:04:13 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593053: rkdb: adns restart: bridge
Feb 26 11:04:13 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593053: rkdb: Connecting bridge (step 1) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:04:13 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593053: rkdb: Connecting bridge (step 2) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:04:13 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593053: rkdb: Connecting bridge (step 3) bridge (emqx.prd.lvt.services)
Feb 26 11:04:18 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593058: rkdb: setting restart time to 5 seconds from now
Feb 26 11:04:23 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593063: rkdb: connection is down - checking if I should try to restart: bridge
Feb 26 11:04:24 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593064: rkdb: adns restart: bridge
Feb 26 11:04:24 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593064: rkdb: Connecting bridge (step 1) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:04:24 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593064: rkdb: Connecting bridge (step 2) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:04:24 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593064: rkdb: Connecting bridge (step 3) bridge (emqx.prd.lvt.services)
Feb 26 11:04:29 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593069: rkdb: setting restart time to 5 seconds from now
Feb 26 11:04:33 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593073: rkdb: connection is down - checking if I should try to restart: bridge
Feb 26 11:04:35 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593075: rkdb: adns restart: bridge
Feb 26 11:04:35 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593075: rkdb: Connecting bridge (step 1) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:04:35 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593075: rkdb: Connecting bridge (step 2) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:04:35 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593075: rkdb: Connecting bridge (step 3) bridge (emqx.prd.lvt.services)
Feb 26 11:04:40 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593080: rkdb: setting restart time to 5 seconds from now
Feb 26 11:04:45 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593085: rkdb: connection is down - checking if I should try to restart: bridge
Feb 26 11:04:46 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593086: rkdb: adns restart: bridge
Feb 26 11:04:46 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593086: rkdb: Connecting bridge (step 1) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:04:46 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593086: rkdb: Connecting bridge (step 2) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:04:46 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593086: rkdb: Connecting bridge (step 3) bridge (emqx.prd.lvt.services)
Feb 26 11:04:51 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593091: rkdb: setting restart time to 5 seconds from now
Feb 26 11:04:56 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593096: rkdb: connection is down - checking if I should try to restart: bridge
Feb 26 11:04:57 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593097: rkdb: adns restart: bridge
Feb 26 11:04:57 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593097: rkdb: Connecting bridge (step 1) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:04:57 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593097: rkdb: Connecting bridge (step 2) bridge (emqx.prd.lvt.services:8883)
Feb 26 11:04:57 LVT-RPI-EDGE-V402 mosquitto[495095]: 1740593097: rkdb: Connecting bridge (step 3) bridge (emqx.prd.lvt.services)
```