### PR TITLE
fix: [JET-34564] fix info log

### DIFF
--- a/src/bridge.c
+++ b/src/bridge.c
@@ -194,7 +194,7 @@ int is_it_time_to_retry_connect() {
 			target_reconnect_time_s = db.now_s;
 		} else {
 			target_reconnect_time_s = max(last_connect_attempt_time_s + increasing_wait_time_s, db.now_s) + jitter;
-			log__printf(NULL, MOSQ_LOG_INFO, "rkdb: reconnect needed: backoff_wait_time_s=%ds, since-last=%ld, jitter=%ds, time-left=%lds",
+			log__printf(NULL, MOSQ_LOG_INFO, "rkdb: reconnect needed: backoff_wait_time_s=%ds, since-last=%lds, jitter=%ds, time-left=%lds",
 				    increasing_wait_time_s, db.now_s - last_connect_attempt_time_s, jitter, target_reconnect_time_s - db.now_s);
 		}
 		return false;


### PR DESCRIPTION
## Purpose
While testing one more time, I noticed an info log that is slightly confusing and can be fixed by adding the unit ("s" for seconds) to one of the output values.

The log output I'm changing looks like this before the change:
```
rkdb: reconnect needed: backoff_wait_time_s=30s, since-last=329, jitter=9s, time-left=9s
```
and it will look like this after (note the "s" after `since-last=329` to indicate seconds):
```
rkdb: reconnect needed: backoff_wait_time_s=30s, since-last=329s, jitter=9s, time-left=9s
```

## Testing
* mosquitto regression testing
* sever the connection, and observe that it adds a jitter time before trying to reconnect the first time (@Ty Merrill , I can do this on my test unit, so you can just focus on the regression testing if you don’t have a good way to do this).