### PR TITLE
[JET-16169] More logging tweaks

### DIFF
--- a/lib/handle_ping.c
+++ b/lib/handle_ping.c
@@ -56,6 +56,8 @@ int handle__pingreq(struct mosquitto *mosq)
 	return send__pingresp(mosq);
 }
 
+static long ping_resp_count = 0;
+
 int handle__pingresp(struct mosquitto *mosq)
 {
 	assert(mosq);
@@ -69,7 +71,11 @@ int handle__pingresp(struct mosquitto *mosq)
 	if(mosq->bridge == NULL){
 		return MOSQ_ERR_PROTOCOL;
 	}
-	log__printf(NULL, MOSQ_LOG_INFO, "Received PINGRESP from %s", SAFE_PRINT(mosq->id));
+  if (ping_resp_count++ % 30 == 0) {
+    log__printf(NULL, MOSQ_LOG_INFO, "Received PINGRESP from %s", SAFE_PRINT(mosq->id));
+  } else {
+    log__printf(NULL, MOSQ_LOG_DEBUG, "Received PINGRESP from %s", SAFE_PRINT(mosq->id));
+  }
 #else
 	log__printf(mosq, MOSQ_LOG_DEBUG, "Client %s received PINGRESP", SAFE_PRINT(mosq->id));
 #endif

--- a/lib/send_mosq.c
+++ b/lib/send_mosq.c
@@ -46,9 +46,7 @@ int send__pingreq(struct mosquitto *mosq)
 	int rc;
 	assert(mosq);
 #ifdef WITH_BROKER
-  if (mosq->is_bridge) {
-    log__printf(NULL, MOSQ_LOG_INFO, "Sending PINGREQ to %s", SAFE_PRINT(mosq->id));
-  }
+  log__printf(NULL, MOSQ_LOG_DEBUG, "Sending PINGREQ to %s", SAFE_PRINT(mosq->id));
 #else
 	log__printf(mosq, MOSQ_LOG_DEBUG, "Client %s sending PINGREQ", SAFE_PRINT(mosq->id));
 #endif


### PR DESCRIPTION
## Purpose
There are still enough logs being output during normal operation that I will likely lose the info I need when an event happens.  This PR quiets the PING logs so that only the PINGRESP logs will appear in the journald logs once every ~5mins.

## Testing
* run mosquitto - check that the logs are as described above
* mosquitto regression tests